### PR TITLE
Changing text color on hover proposal

### DIFF
--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -106,7 +106,7 @@ const EditGithub = styled.a`
 
   &:hover {
     background: ${(props) => props.theme.secondaryColor};
-    color: white;
+    color: #CACACA;
   }
 `
 


### PR DESCRIPTION
Since the background goes to a kind of light yellow, if the color of the text is in white and it will not be readable, this can be little bit confusing. I would like to suggest to take into consideration using a grey color.

I have chosen that grey in order to have the same value as the one used in the last update date element at the end of the blog. But  a lighter grey can match too.